### PR TITLE
Fixes Unable to Interact after dropping item

### DIFF
--- a/LethalProgression/Patches/HudManagerPatch.cs
+++ b/LethalProgression/Patches/HudManagerPatch.cs
@@ -133,7 +133,7 @@ namespace LethalProgression.Patches
         private static void MakeBar()
         {
             QuickMenuManagerPatch.MakeNewXPBar();
-            GameObject _xpBar = GameObject.Find("/Systems/UI/Canvas/QuickMenu/XPBar");
+            GameObject _xpBar = GameObject.Find("/Systems/UI/Canvas/QuickMenu/XpInfoContainer/XPBar");
             _tempBar = GameObject.Instantiate(_xpBar);
             _tempBar.name = "XPUpdate";
 


### PR DESCRIPTION
After dropping an item on the ship you can't interact with anything with E nor switch between the equipped items, your are basically stuck. This commit fixes this bug.